### PR TITLE
Fixed collection display mode

### DIFF
--- a/ting_search.make
+++ b/ting_search.make
@@ -4,5 +4,5 @@ core = 7.x
 ; Ding!
 projects[ting][type] = "module"
 projects[ting][download][type] = "git"
-projects[ting][download][url] = "git@github.com:ding2tal/ting.git"
+projects[ting][download][url] = "git@github.com:ding2/ting.git"
 projects[ting][download][tag] = "7.x-0.22"


### PR DESCRIPTION
When display the search result snippet the view mode was hardcode to 'teaser', this PR fixes that issue.

See [lighthouse ticket 9](https://libraryding.lighthouseapp.com/projects/81497-ding2/tickets/9-default-view-mode-hardcoded-til-teaser)
