### PR TITLE
Reintroduce "remove ting_scan_url and ting_spell_url""

### DIFF
--- a/ting_search.test
+++ b/ting_search.test
@@ -16,8 +16,6 @@ class TingSearchTestCase extends DrupalWebTestCase {
     parent::setUp('ting', 'ding_entity', 'search', 'ting_search', 'nanosoap');
     variable_set('ting_agency', '100200');
     variable_set('ting_search_url', 'http://opensearch.addi.dk/next_2.0/');
-    variable_set('ting_scan_url', 'http://openscan.addi.dk/1.5/');
-    variable_set('ting_spell_url', 'http://openspell.addi.dk/1.2/');
     variable_set('ting_recommendation_url', 'http://openadhl.addi.dk/1.1/');
     variable_set('search_active_modules', array('ting_search' => 'ting_search'));
     variable_set('ting_search_profile', 'opac');


### PR DESCRIPTION
Reverts ding2/ting_search#24

This change has been reviewed and approved. It should be merged when it fits into the release plan.
