### PR TITLE
Fix parsing of search string. Closes #1395.

### DIFF
--- a/tests/ting_search.test
+++ b/tests/ting_search.test
@@ -172,6 +172,35 @@ class TingSearchParsingTestCase extends DrupalUnitTestCase {
           'dc.title' => 'flammernes pokal',
         ),
       ),
+      // Regression tests.
+      array(
+        'string' => 'banana and (dk=sk)',
+        'keys' => array('term.creator', 'term.title', 'term.subject'),
+        'expected' => array(
+          'q' => 'banana and (dk=sk)',
+        ),
+      ),
+      array(
+        'string' => 'banana AND (dk=sk)',
+        'keys' => array('term.creator', 'term.title', 'term.subject'),
+        'expected' => array(
+          'q' => 'banana and (dk=sk)',
+        ),
+      ),
+      array(
+        'string' => '(dk=sk)',
+        'keys' => array('term.creator', 'term.title', 'term.subject'),
+        'expected' => array(
+          'q' => '(dk=sk)',
+        ),
+      ),
+      array(
+        'string' => '(term.type="bog" OR term.type="ebog") AND (term.subject="fantasy" OR term.subject="krimi")',
+        'keys' => array('term.creator', 'term.title', 'term.subject'),
+        'expected' => array(
+          'q' => '(term.type="bog" OR term.type="ebog") and (term.subject="fantasy" OR term.subject="krimi")',
+        ),
+      ),
     );
     foreach ($testCases as $test) {
       drupal_static_reset('ting_search_extract_indexes');

--- a/ting_search.module
+++ b/ting_search.module
@@ -302,6 +302,8 @@ function ting_search_extract_keys($search_query, $keys) {
     $search_query = preg_replace_callback($regexp, 'ting_search_extract_indexes', $search_query);
   }
 
+  // Remove any leading and's.
+  $search_query = preg_replace('/^ and \\(/', '(', $search_query);
   $indexes['q'] = $search_query;
   return $indexes;
 }
@@ -318,7 +320,7 @@ function ting_search_extract_indexes($matches, $set_keys = NULL) {
   $subexps = preg_split('/\s+and\s+/i', $matches[2], NULL, PREG_SPLIT_NO_EMPTY);
   $indexes = &drupal_static(__FUNCTION__, array());
   foreach ($subexps as $subexp) {
-    if ((preg_match('/^([^=]+)\=([^"]*)$/', $subexp, $rx) || preg_match('/^([^=]+)\="(.*)"$/', $subexp, $rx)) && array_key_exists(trim($rx[1]), $keys)) {
+    if ((preg_match('/^([^=]+)\=([^"]*)$/', $subexp, $rx) || preg_match('/^([^=]+)\="([^"]*)"$/', $subexp, $rx)) && array_key_exists(trim($rx[1]), $keys)) {
       $indexes[trim($rx[1])] = trim($rx[2]);
     }
     else {


### PR DESCRIPTION
Some searches confuses the facet extractor and results in wrong query being shown to the user. This fixes it.